### PR TITLE
configure host mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 ZT_NETWORK=
+ZT_MOUNT=/mnt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /config.yaml
 gh-pages
 public
+/mnt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
     devices:
     - /dev/net/tun
     volumes:
-    - ./etc/zerotier:/var/lib/zerotier-one
+    - ${ZT_MOUNT}/zerotier:/var/lib/zerotier-one
     restart: always

--- a/etc/zerotier/.gitignore
+++ b/etc/zerotier/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Zerotier stores its configuration (state) on host directories.  Make the host directory configurable in `.env`.